### PR TITLE
fix(msvc): add MSVC-portable oalloc/ofree + builtin shims

### DIFF
--- a/gf2.h
+++ b/gf2.h
@@ -4,6 +4,21 @@
 #include <stdint.h>
 #include <stdio.h>
 
+/* MSVC compatibility shims for the GCC/Clang bit-twiddling builtins
+   used in gf2.c. Mirrors the equivalent block in oblas.h; we duplicate
+   it here so gf2.c does not need to pull in the full oblas API. */
+#if defined(_MSC_VER) && !defined(__clang__)
+#include <intrin.h>
+static __inline int __builtin_ctz(uint32_t x) {
+  unsigned long r = 0;
+  _BitScanForward(&r, x);
+  return (int)r;
+}
+static __inline int __builtin_popcount(uint32_t x) {
+  return (int)__popcnt(x);
+}
+#endif
+
 #define gf2word uint32_t
 #define gf2wsz (sizeof(gf2word) * 8)
 

--- a/oblas.c
+++ b/oblas.c
@@ -1,14 +1,38 @@
 #include "oblas.h"
 #include <errno.h>
+#include <stdlib.h>
+
+#if defined(_MSC_VER)
+#include <malloc.h>
+#endif
 
 void *oalloc(size_t nmemb, size_t size, size_t align) {
-  void *aligned = NULL;
   size_t aligned_sz = ((size / align) + ((size % align) ? 1 : 0)) * align;
+  size_t total = nmemb * aligned_sz;
 
-  if (posix_memalign((void *)&aligned, align, nmemb * aligned_sz) != 0) {
+#if defined(_MSC_VER)
+  /* Argument order is (size, align), opposite of posix_memalign. */
+  void *aligned = _aligned_malloc(total, align);
+  if (!aligned) {
     exit(ENOMEM);
   }
   return aligned;
+#else
+  void *aligned = NULL;
+  if (posix_memalign(&aligned, align, total) != 0) {
+    exit(ENOMEM);
+  }
+  return aligned;
+#endif
+}
+
+void ofree(void *ptr) {
+  if (!ptr) return;
+#if defined(_MSC_VER)
+  _aligned_free(ptr);
+#else
+  free(ptr);
+#endif
 }
 
 #ifdef OBLAS_SSE

--- a/oblas.h
+++ b/oblas.h
@@ -6,6 +6,21 @@
 #include "octmat.h"
 #include "octtables.h"
 
+/* MSVC compatibility shims — provide GCC/Clang builtins used by the
+   bit-twiddling routines in oblas_classic.c. Safe to include from C
+   and C++. */
+#if defined(_MSC_VER) && !defined(__clang__)
+#include <intrin.h>
+static __inline int __builtin_ctz(uint32_t x) {
+  unsigned long r = 0;
+  _BitScanForward(&r, x);
+  return (int)r;
+}
+static __inline int __builtin_popcount(uint32_t x) {
+  return (int)__popcnt(x);
+}
+#endif
+
 #define OCTET_MUL(u, v) OCT_EXP[OCT_LOG[u] + OCT_LOG[v]]
 #define OCTET_DIV(u, v) OCT_EXP[OCT_LOG[u] - OCT_LOG[v] + 255]
 #define OCTET_SWAP(u, v)                                                       \
@@ -20,7 +35,15 @@
 
 typedef uint8_t octet;
 
+/* Aligned allocator. On POSIX uses posix_memalign; on MSVC uses
+   _aligned_malloc. Memory returned MUST be freed with ofree(), not
+   plain free(), or the heap will be corrupted on Windows. */
 void *oalloc(size_t nmemb, size_t size, size_t align);
+
+/* Companion deallocator for memory returned by oalloc(). Matches
+   _aligned_free under MSVC and plain free() elsewhere. Calling
+   ofree(NULL) is a no-op. */
+void ofree(void *ptr);
 
 void ocopy(uint8_t *a, uint8_t *b, size_t i, size_t j, size_t k);
 void oswaprow(uint8_t *a, size_t i, size_t j, size_t k);

--- a/octmat.c
+++ b/octmat.c
@@ -27,7 +27,7 @@ void om_destroy(octmat *v) {
   v->rows = 0;
   v->cols = 0;
   v->cols_al = 0;
-  free(v->data);
+  ofree(v->data);
   v->data = NULL;
 }
 


### PR DESCRIPTION
## Summary

Lets `oblas` compile under MSVC on Windows. Three small portability fixes:

1. **`oalloc`** — uses `_aligned_malloc` on `_MSC_VER`, `posix_memalign` elsewhere. The argument order differs (`size, align` vs `&out, align, size`) but behaviour is equivalent.
2. **`ofree`** (new) — companion deallocator. Required because memory from `_aligned_malloc` MUST be freed with `_aligned_free`, NOT plain `free()` — that corrupts the CRT heap on Windows.
3. **MSVC builtin shims** — `oblas.h` and `gf2.h` provide static-inline wrappers for `__builtin_ctz` (via `_BitScanForward`) and `__builtin_popcount` (via `__popcnt`) so `oblas_classic.c` and `gf2.c` compile on MSVC.

`octmat.c::om_destroy` switches the one site that frees `oalloc`'d memory: `free(v->data)` → `ofree(v->data)`. All other `free()` calls in oblas operate on `calloc`'d memory and remain plain `free()`.

## POSIX behaviour

Unchanged. The MSVC code paths are gated on `_MSC_VER`.

## Diff size

4 files / +65 / −3.

## Why this fork

Branched off the commit `Backbone-Labs/nanorq` pins (`877a4bf`) rather than current `master`, because the file structure has diverged in newer commits and we want a minimal targeted patch against the version `nanorq` actually uses. If upstream `sleepybishop` accepts a similar patch, we delete this fork.

## Test plan

- [ ] POSIX: confirm no behaviour change (the diff is `_MSC_VER`-gated).
- [ ] MSVC: `cloudgame_core` + `cloudgame_host` + `cloudgame_client` build clean against nanorq linked with this oblas. Verified in the consuming `neo-fuji` sidecar.

## Consuming PRs

- https://github.com/Backbone-Labs/nanorq/pull/1 — bumps oblas pointer, adds matching MSVC portability fixes
- https://github.com/Backbone-Labs/ikigai-custom-udp-protocol/pull/42 — bumps nanorq pointer, drops Windows return-early in BuildNanorq.cmake